### PR TITLE
fix: added the delete_branch_on_merge to the list

### DIFF
--- a/githuborganizer/models/gh.py
+++ b/githuborganizer/models/gh.py
@@ -312,7 +312,7 @@ class Repository:
                 if feature in settings:
                     settings['features'][feature] = settings[feature]
                     del settings[feature]
-            for merge in ['allow_rebase_merge', 'allow_squash_merge', 'allow_merge_commit']:
+            for merge in ['allow_rebase_merge', 'allow_squash_merge', 'allow_merge_commit', 'delete_branch_on_merge']:
                 if merge in settings:
                     settings['merges'][merge] = settings[merge]
                     del settings[merge]


### PR DESCRIPTION
Each merge value was included in the get_organizer_settings function and that seemed to be missing for the delete_branch_on_merge option so it is included in this now.